### PR TITLE
FIX - Carriers filters for payments

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -601,9 +601,28 @@ class HookCore extends ObjectModel
                     $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") AND (SELECT `id_currency` FROM `'._DB_PREFIX_.'module_currency` mcr WHERE mcr.`id_module` = m.`id_module` AND `id_currency` IN ('.(int)$context->currency->id.', -1, -2) LIMIT 1) IN ('.(int)$context->currency->id.', -1, -2))');
                 }
                 if (Validate::isLoadedObject($context->cart)) {
-                    $carrier = new Carrier($context->cart->id_carrier);
-                    if (Validate::isLoadedObject($carrier)) {
-                        $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") AND (SELECT `id_reference` FROM `'._DB_PREFIX_.'module_carrier` mcar WHERE mcar.`id_module` = m.`id_module` AND `id_reference` = '.(int)$carrier->id_reference.' AND `id_shop` = '.(int)$context->shop->id.' LIMIT 1) = '.(int)$carrier->id_reference.')');
+                    SQLsubquery = '';
+                    $carriers = [];
+                    $cartCarriers = $context->cart->getDeliveryOption();
+                    foreach ($cartCarriers as $cartCarriersRow) {
+                        $cartCarriersData = explode(',', $cartCarriersRow);
+                        foreach ($cartCarriersData as $carrierId) {
+                            if(empty($carrierId)){
+                                continue;
+                            }
+                            $carrier = new Carrier($carrierId);
+                            if (!Validate::isLoadedObject($carrier)){
+                                continue;
+                            }
+                            $carrierRef = $carrier->id_reference;
+                            if (!in_array($carrierRef, $carriers)) {
+                                $carriers[] = $carrierRef;
+                                $SQLsubquery.=' AND (SELECT `id_reference` FROM `'._DB_PREFIX_.'module_carrier` mcar WHERE mcar.`id_module` = m.`id_module` AND `id_reference` = '.(int)$carrierRef.' AND `id_shop` = '.(int)$context->shop->id.' LIMIT 1) = '.(int)$carrierRef;
+                            }
+                        }
+                    }
+                    if (!empty($carriers)) {
+                        $sql->where('((h.`name` = "displayPayment" OR h.`name` = "displayPaymentEU" OR h.`name` = "paymentOptions") '.$SQLsubquery.')');
                     }
                 }
             }


### PR DESCRIPTION
The original code didn't work properly if the context cart had a multicarrier choice. It took the context carrier using the $context->cart->id_carrier property which is blank on multi-carrier carts.

The new code gets the full selected carriers list, then iterates it ignoring the repeated ones and creating the final subquery.
It works properly for both situations (multi-carrier and single-carrier carts).

<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information: -->

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | The original code didn't work properly if the context cart had a multicarrier choice. It took the context carrier using the $context->cart->id_carrier property which is blank on multi-carrier carts.

The new code gets the full selected carriers list, then iterates it ignoring the repeated ones and creating the final subquery.
It works properly for both situations (multi-carrier and single-carrier carts).
| Type?         | bug fix
| Category?     | CO
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | 
| How to test?  | Just create two products and link each one to different carriers, it will force a multicarrier cart. Then set up the payment modules avoiding bankwire (for example) in one of this carriers. 

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->

#### Important guidelines

* Make sure [your local branch is up to date](https://help.github.com/articles/syncing-a-fork/) before commiting your changes!
* Your code MUST respect [our Coding Standards](http://doc.prestashop.com/display/PS16/Coding+Standards) (for code written in PHP, JavaScript, HTML/CSS/Smarty/Twig, SQL)!
* Your commit name MUST respect our [naming convention](http://doc.prestashop.com/display/PS16/How+to+write+a+commit+message)!
